### PR TITLE
Adds support for Domain Tokens

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,6 +14,13 @@ class AuthTestCase(unittest.TestCase):
         dns = DNSimple(email='chris.morgan@youngshand.com', api_token='L0lkPizHnqVrsIyViLpB', sandbox=True)
         self.assertTrue(type(dns.domains()) is list)
 
+    def test_domain_token_auth(self):
+        # FIXME: Needs proper/publishable credentials/domain to work on sandbox
+        dns = DNSimple(domain_token='DOMAIN_TOKEN', sandbox=True)
+        with self.assertRaises(DNSimpleException):
+            self.assertTrue(type(dns.domains()) is list)
+        self.assertTrue(type(dns.records('DOMAIN')) is list)
+
     def test_config_auth(self):
         dns = DNSimple(sandbox=True)
         self.assertTrue(type(dns.domains()) is list)


### PR DESCRIPTION
DNSimple supports API tokens that have access to only one domain. This implements support for these tokens.

`dns = DNSimple(domain_token=TOKEN)`

Also includes a (currently failing) test, though that'd need to be changed by @mikemaccana to use credentials and a domain that are publishable and work in the sandbox.