### PR TITLE
Adds shell environment string interpolation to .dnsimple config

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,12 @@ You can provide your DNSimple credentials in one of two ways:
         email: email@domain.com
         api_token: yourapitoken
 
+    Or (assuming `$DNSIMPLE_EMAIL` and `$DNSIMPLE_TOKEN` are environment variables):
+
+        [DNSimple]
+        email: %(DNSIMPLE_EMAIL)s
+        api_token: %(DNSIMPLE_TOKEN)s
+
     You then need not provide any credentials when constructing `DNSimple`:
 
         dns = DNSimple()

--- a/dnsimple/dnsimple.py
+++ b/dnsimple/dnsimple.py
@@ -67,13 +67,15 @@ class DNSimple(object):
         self.__user_agent = 'DNSimple Python API {version}'.format(version=__version__)
 
         if email is None and api_token is None and domain_token is None and username is None and password is None:
-            config = configparser.ConfigParser(defaults={
+            defaults = dict(os.environ)            
+            defaults.update({
                 'username': None,
                 'password': None,
                 'email': None,
                 'api_token': None,
                 'domain_token': None
             })
+            config = configparser.ConfigParser(defaults=defaults)
             for cfg in ['.dnsimple', os.path.expanduser('~/.dnsimple')]:
                 if os.path.exists(cfg):
                     config.read(cfg)


### PR DESCRIPTION
I tried to write this patch in such a way that it should not interfere with any existing use cases.

Adds string interpolation to the `.dnsimple` file so you can use shell environment variables.